### PR TITLE
Feature #42866: Add project selector component

### DIFF
--- a/EchoFramework/package-lock.json
+++ b/EchoFramework/package-lock.json
@@ -16,7 +16,7 @@
                 "@babel/preset-env": "^7.12.11",
                 "@babel/preset-react": "^7.12.10",
                 "@equinor/echo-components": "^0.1.4",
-                "@equinor/echo-core": "^0.2.94",
+                "@equinor/echo-core": "0.2.106",
                 "@equinor/echo-scripts": "^0.1.5",
                 "@equinor/echo-utils": "^0.0.9",
                 "@equinor/eds-core-react": "^0.11.1",
@@ -66,7 +66,7 @@
             },
             "peerDependencies": {
                 "@equinor/echo-components": "^0.1.4",
-                "@equinor/echo-core": "^0.2.94",
+                "@equinor/echo-core": "^0.2.106",
                 "@equinor/eds-core-react": "^0.11.1",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
@@ -1612,9 +1612,9 @@
             "dev": true
         },
         "node_modules/@equinor/echo-base": {
-            "version": "0.2.96",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.2.96.tgz",
-            "integrity": "sha512-jQ/Y/LeurQ0vMRd2e4Wi0OGSAgSIdjFQ0ZLIjVqQuQwj8GD6Gb6ijwq0EJhpZ7/mRe6+9koE8m/1OW+gtXUDiw==",
+            "version": "0.2.104",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.2.104.tgz",
+            "integrity": "sha512-f8+XS3xH2yKBSQGGlzaJBm/ETQp9ed7SnCUAVZ2PyJix/Q6iTEeFWdhenEKGD+98NZBattXgr0DSbcGP9CJAXw==",
             "dependencies": {
                 "tslib": "^2.2.0"
             }
@@ -1636,16 +1636,16 @@
             }
         },
         "node_modules/@equinor/echo-core": {
-            "version": "0.2.94",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-core/-/echo-core-0.2.94.tgz",
-            "integrity": "sha512-44Z4EyLVBLUlH1ddpLufeeuAPh1miQGzSbKOh2qksGuxkHeVWlYGdjdRxPi7Jb8jAOR3lFAwmr1EsmK8sBnAEg==",
+            "version": "0.2.106",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-core/-/echo-core-0.2.106.tgz",
+            "integrity": "sha512-zmrH8rHNDiO6L+aezevcF261uFWLi8UQoDleDi8xQkwroo4mcKClQOjBsLbmDsEHw1oA4scUmfIbVuPRG/Rwvw==",
             "dev": true,
             "dependencies": {
                 "@azure/msal-browser": "^2.8.0",
                 "@dbeining/react-atom": "^4.1.12"
             },
             "peerDependencies": {
-                "@equinor/echo-base": "^0.2.93",
+                "@equinor/echo-base": "^0.2.104",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-router": "^5.2.0",
@@ -20628,9 +20628,9 @@
             "dev": true
         },
         "@equinor/echo-base": {
-            "version": "0.2.96",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.2.96.tgz",
-            "integrity": "sha512-jQ/Y/LeurQ0vMRd2e4Wi0OGSAgSIdjFQ0ZLIjVqQuQwj8GD6Gb6ijwq0EJhpZ7/mRe6+9koE8m/1OW+gtXUDiw==",
+            "version": "0.2.104",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.2.104.tgz",
+            "integrity": "sha512-f8+XS3xH2yKBSQGGlzaJBm/ETQp9ed7SnCUAVZ2PyJix/Q6iTEeFWdhenEKGD+98NZBattXgr0DSbcGP9CJAXw==",
             "requires": {
                 "tslib": "^2.2.0"
             }
@@ -20645,9 +20645,9 @@
             }
         },
         "@equinor/echo-core": {
-            "version": "0.2.94",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-core/-/echo-core-0.2.94.tgz",
-            "integrity": "sha512-44Z4EyLVBLUlH1ddpLufeeuAPh1miQGzSbKOh2qksGuxkHeVWlYGdjdRxPi7Jb8jAOR3lFAwmr1EsmK8sBnAEg==",
+            "version": "0.2.106",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-core/-/echo-core-0.2.106.tgz",
+            "integrity": "sha512-zmrH8rHNDiO6L+aezevcF261uFWLi8UQoDleDi8xQkwroo4mcKClQOjBsLbmDsEHw1oA4scUmfIbVuPRG/Rwvw==",
             "dev": true,
             "requires": {
                 "@azure/msal-browser": "^2.8.0",

--- a/EchoFramework/package.json
+++ b/EchoFramework/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-framework",
-    "version": "0.0.69",
+    "version": "0.0.71",
     "description": "Modules and components for EchoWeb, utilizing EchoCore",
     "main": "dist/src/index.js",
     "types": "dist/types/index.d.ts",
@@ -26,7 +26,7 @@
     },
     "peerDependencies": {
         "@equinor/echo-components": "^0.1.4",
-        "@equinor/echo-core": "^0.2.94",
+        "@equinor/echo-core": "^0.2.106",
         "@equinor/eds-core-react": "^0.11.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -38,7 +38,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@equinor/echo-components": "^0.1.4",
-        "@equinor/echo-core": "^0.2.94",
+        "@equinor/echo-core": "^0.2.106",
         "@equinor/echo-scripts": "^0.1.5",
         "@equinor/echo-utils": "^0.0.9",
         "@equinor/eds-core-react": "^0.11.1",

--- a/EchoFramework/src/__tests__/projectSelectorUtils.test.ts
+++ b/EchoFramework/src/__tests__/projectSelectorUtils.test.ts
@@ -1,0 +1,24 @@
+import { filterProjectsStartsWithFirst } from '../utils/projectSelectorUtils';
+
+describe('filterProjectsStartsWithFirst', () => {
+    it('should filter a list of strings', () => {
+        const strings = ['onefilter', 'twofilter', 'three', 'four'];
+        const filteredStrings = filterProjectsStartsWithFirst(strings, 'filter');
+
+        expect(filteredStrings).toEqual(['onefilter', 'twofilter']);
+    });
+
+    it('should show elements that start with the filter first', () => {
+        const strings = ['onefilter', 'filtertwo', 'threefilter', 'four'];
+        const filteredStrings = filterProjectsStartsWithFirst(strings, 'filter');
+
+        expect(filteredStrings).toEqual(['filtertwo', 'onefilter', 'threefilter']);
+    });
+
+    it('should be case insensitive', () => {
+        const strings = ['oneFilter', 'twoFILTER', 'three', 'four'];
+        const filteredStrings = filterProjectsStartsWithFirst(strings, 'FiLtEr');
+
+        expect(filteredStrings).toEqual(['oneFilter', 'twoFILTER']);
+    });
+});

--- a/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
+++ b/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
@@ -6,6 +6,7 @@ import {
     useProcosysProjects
 } from '@equinor/echo-core';
 import React from 'react';
+import { filterProjectsStartsWithFirst } from '../../utils/projectSelectorUtils';
 
 interface ProjectSelectorProps {
     variant?: 'compact' | 'default';
@@ -43,16 +44,12 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
         }
     };
 
-    const filterProjects = (data: string[], filter: string): string[] => {
-        return data.filter((item) => item.toLowerCase().indexOf(filter.trim().toLowerCase()) > -1);
-    };
-
     return (
         <Dropdown
             showSearch={true}
             selected={selectedProcosysProjectCode}
             data={dropdownProcosysProjects}
-            filterFunc={filterProjects}
+            filterFunc={filterProjectsStartsWithFirst}
             openDownWards={true}
             placeholder="Select ProCoSys project"
             setSelected={handleProcosysProjectSelected}

--- a/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
+++ b/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
@@ -34,9 +34,10 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     dropdownProcosysProjects.unshift(ALL_PROJECTS);
 
     const handleProcosysProjectSelected = async (projectCode: string): Promise<void> => {
-        const newSelectedProcosysProject = procosysProjects.find(
-            (project: ProcosysProject) => project.projectCode === projectCode
-        );
+        const newSelectedProcosysProject =
+            projectCode === ALL_PROJECTS
+                ? ({ projectCode: ALL_PROJECTS } as ProcosysProject)
+                : procosysProjects.find((project: ProcosysProject) => project.projectCode === projectCode);
         if (newSelectedProcosysProject) {
             setSelectedProcosysProject(newSelectedProcosysProject);
         }
@@ -56,7 +57,7 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             placeholder="Select ProCoSys project"
             setSelected={handleProcosysProjectSelected}
             isDisabled={isDisabled || !navigator.onLine}
-            disabledText="Disabled while syncing or loading data"
+            disabledText="Disabled"
             maxCharacterCount={maxCharacterCount}
             variant={variant ? variant : 'default'}
         />

--- a/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
+++ b/EchoFramework/src/components/projectSelector/ProcosysProjectSelector.tsx
@@ -1,0 +1,64 @@
+import { Dropdown } from '@equinor/echo-components';
+import {
+    ProcosysProject,
+    setSelectedProcosysProject,
+    useProcosysProjectCode,
+    useProcosysProjects
+} from '@equinor/echo-core';
+import React from 'react';
+
+interface ProjectSelectorProps {
+    variant?: 'compact' | 'default';
+    maxCharacterCount?: number;
+    isDisabled?: boolean;
+}
+
+export const ALL_PROJECTS = 'All projects';
+
+/**
+ * Dropdown component for displaying a searchable project selector.
+ * @param {ProjectSelectorProps} {
+ * variant: The style type for the dropdown component. Either default or compact.
+ * isDisabled: Flag which decides whether the dropdown should be disabled or not.
+ * }
+ * @return {*}
+ */
+export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
+    variant,
+    maxCharacterCount,
+    isDisabled
+}: ProjectSelectorProps) => {
+    const selectedProcosysProjectCode = useProcosysProjectCode();
+    const procosysProjects = useProcosysProjects();
+    const dropdownProcosysProjects = procosysProjects.map((project) => project.projectCode);
+    dropdownProcosysProjects.unshift(ALL_PROJECTS);
+
+    const handleProcosysProjectSelected = async (projectCode: string): Promise<void> => {
+        const newSelectedProcosysProject = procosysProjects.find(
+            (project: ProcosysProject) => project.projectCode === projectCode
+        );
+        if (newSelectedProcosysProject) {
+            setSelectedProcosysProject(newSelectedProcosysProject);
+        }
+    };
+
+    const filterProjects = (data: string[], filter: string): string[] => {
+        return data.filter((item) => item.toLowerCase().indexOf(filter.trim().toLowerCase()) > -1);
+    };
+
+    return (
+        <Dropdown
+            showSearch={true}
+            selected={selectedProcosysProjectCode}
+            data={dropdownProcosysProjects}
+            filterFunc={filterProjects}
+            openDownWards={true}
+            placeholder="Select ProCoSys project"
+            setSelected={handleProcosysProjectSelected}
+            isDisabled={isDisabled || !navigator.onLine}
+            disabledText="Disabled while syncing or loading data"
+            maxCharacterCount={maxCharacterCount}
+            variant={variant ? variant : 'default'}
+        />
+    );
+};

--- a/EchoFramework/src/index.ts
+++ b/EchoFramework/src/index.ts
@@ -1,11 +1,13 @@
 export { default as PageMenu } from './components/pageMenu/pageMenu';
 export { default as PlantSelector } from './components/plantSelector/plantSelector';
+export * from './components/projectSelector/ProcosysProjectSelector';
 export { default as Toast } from './components/toaster/toaster';
 export { default as Toasters } from './components/toaster/toasters';
 export { default as EchoContent } from './coreApplication/EchoContent';
-export { mainMenu, searchPanel } from './coreApplication/EchoContentPanels';
+export * from './coreApplication/EchoContentPanels';
 export { default as EchoEventHandler } from './coreApplication/EchoEventHandler';
-export { themeConst } from './theme/themeConst';
+export * from './theme/themeConst';
 export type { ToasterEvent } from './types/toasterEvent';
-export { startup } from './utils/startup';
+export * from './utils/startup';
 import './theme/theme.css';
+

--- a/EchoFramework/src/utils/projectSelectorUtils.ts
+++ b/EchoFramework/src/utils/projectSelectorUtils.ts
@@ -1,0 +1,8 @@
+export function filterProjectsStartsWithFirst(data: string[], filter: string): string[] {
+    const startsWithData = data.filter((item) => item.toLowerCase().startsWith(filter.toLowerCase()));
+    const includesData = data
+        .filter((item) => item.toLowerCase().includes(filter.toLowerCase()))
+        .filter((item) => !startsWithData.includes(item));
+
+    return startsWithData.concat(includesData);
+}


### PR DESCRIPTION
Added procosys project selector components.
Also, changed some exports to `export * from` where we don't use default exports.

Developed and tested in the EchopediaWeb repo.
Some screenshots of how it looks in the side panel:

Before selection:
![image](https://user-images.githubusercontent.com/74668394/122244592-4a93a000-cec5-11eb-9445-31b7ab735fd9.png)

Opened:
![image](https://user-images.githubusercontent.com/74668394/122244670-57b08f00-cec5-11eb-8a03-317bbdc1b75a.png)

The "All projects" option will always appear at the top.
